### PR TITLE
Change Learn-LTI to use https authentication for Twitter

### DIFF
--- a/lib/auth.rb
+++ b/lib/auth.rb
@@ -42,7 +42,7 @@ module Sinatra
     module Helpers
       def consumer
         consumer ||= OAuth::Consumer.new(twitter_config.consumer_key, twitter_config.shared_secret, {
-          :site => "http://api.twitter.com",
+          :site => "https://api.twitter.com",
           :request_token_path => "/oauth/request_token",
           :access_token_path => "/oauth/access_token",
           :authorize_path=> "/oauth/authorize",


### PR DESCRIPTION
Fixes PLAT-359

Test plan
- Try http://learn-lti.herokuapp.com/ and make sure that you can "login using your Twitters"
